### PR TITLE
Add documentation workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,37 @@
+name: Generate and deploy documentation
+on:
+  push:
+    branches:
+      - main
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+jobs:
+  docs:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Setup Pages
+      uses: actions/configure-pages@v3
+    - name: Setup JDK
+      uses: actions/setup-java@v3
+      with: 
+        distribution: temurin
+        java-version: 17
+    - name: Generate documentation
+      run: sbt "project sporesJVM ; clean ; doc"
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v1
+      with:
+        path: './jvm/target/scala-3.2.0/api'
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v1
       with:
-        path: './jvm/target/scala-3.2.0/api'
+        path: './jvm/target/api'
     - name: Deploy to GitHub Pages
       id: deployment
       uses: actions/deploy-pages@v1

--- a/build.sbt
+++ b/build.sbt
@@ -55,6 +55,7 @@ lazy val spores = crossProject(JVMPlatform, JSPlatform)
   .in(file("."))
   .settings(
     name := "spores3",
+    Compile / doc / target := target.value / "api",
     libraryDependencies += "com.lihaoyi" %%% "upickle" % upickleVersion,
   )
   .jvmSettings(


### PR DESCRIPTION
This adds GitHub Actions workflow docs.yml which builds API documentation and deploys it to GitHub Pages. To make it able to work, you will need to change settings: on GitHub page Settings->Pages of the repository change Source to GitHub Actions. The documentation will be available at [phaller.github.io/spores3](http://phaller.github.io/spores3). It is possible to set up different domain name for the docs site, for example api.spores3.phaller.com: the domain name should point to GitHub and Custom domain on page Settings->Pages needs to be set to api.spores3.phaller.com.

In order to remove dependency on the used Scala version, build.sbt is also changed: target directory for docs is set up to be target/api instead of target/scala-{version}/api.