### PR TITLE
Change package name

### DIFF
--- a/js/src/main/scala/com/phaller/spores/Creator.scala
+++ b/js/src/main/scala/com/phaller/spores/Creator.scala
@@ -1,4 +1,4 @@
-package com.phaller.spores
+package spores
 
 import scala.scalajs.js.annotation.{JSExportTopLevel, JSExport}
 import scala.scalajs.reflect.Reflect

--- a/js/src/test/scala/com/phaller/spores/upickle/test/AppendString.scala
+++ b/js/src/test/scala/com/phaller/spores/upickle/test/AppendString.scala
@@ -1,8 +1,8 @@
-package com.phaller.spores.pickle.test
+package spores.pickle.test
 
 import scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 
-import com.phaller.spores.Spore
+import spores.Spore
 
 
 @EnableReflectiveInstantiation

--- a/js/src/test/scala/com/phaller/spores/upickle/test/MySpore.scala
+++ b/js/src/test/scala/com/phaller/spores/upickle/test/MySpore.scala
@@ -1,8 +1,8 @@
-package com.phaller.spores.pickle.test
+package spores.pickle.test
 
 import scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 
-import com.phaller.spores.Spore
+import spores.Spore
 
 
 @EnableReflectiveInstantiation

--- a/js/src/test/scala/com/phaller/spores/upickle/test/SporeWithoutEnv.scala
+++ b/js/src/test/scala/com/phaller/spores/upickle/test/SporeWithoutEnv.scala
@@ -1,8 +1,8 @@
-package com.phaller.spores.pickle.test
+package spores.pickle.test
 
 import scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 
-import com.phaller.spores.Builder
+import spores.Builder
 
 
 @EnableReflectiveInstantiation

--- a/jvm/src/main/scala/com/phaller/spores/Creator.scala
+++ b/jvm/src/main/scala/com/phaller/spores/Creator.scala
@@ -1,4 +1,4 @@
-package com.phaller.spores
+package spores
 
 
 private[spores] object Creator {

--- a/jvm/src/test/scala/com/phaller/spores/test/TrieMapTest.scala
+++ b/jvm/src/test/scala/com/phaller/spores/test/TrieMapTest.scala
@@ -1,4 +1,4 @@
-package com.phaller.spores.test
+package spores.test
 
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -6,7 +6,7 @@ import org.junit.runners.JUnit4
 
 import scala.collection.concurrent.TrieMap
 
-import com.phaller.spores.Spore
+import spores.Spore
 
 
 case class Customer(name: String, customerNo: Int)

--- a/jvm/src/test/scala/com/phaller/spores/upickle/test/AppendString.scala
+++ b/jvm/src/test/scala/com/phaller/spores/upickle/test/AppendString.scala
@@ -1,6 +1,6 @@
-package com.phaller.spores.pickle.test
+package spores.pickle.test
 
-import com.phaller.spores.Spore
+import spores.Spore
 
 
 object AppendString extends

--- a/jvm/src/test/scala/com/phaller/spores/upickle/test/MySpore.scala
+++ b/jvm/src/test/scala/com/phaller/spores/upickle/test/MySpore.scala
@@ -1,6 +1,6 @@
-package com.phaller.spores.pickle.test
+package spores.pickle.test
 
-import com.phaller.spores.Spore
+import spores.Spore
 
 
 object MySpore extends Spore.Builder[Int, Int, Int](

--- a/jvm/src/test/scala/com/phaller/spores/upickle/test/SporeWithoutEnv.scala
+++ b/jvm/src/test/scala/com/phaller/spores/upickle/test/SporeWithoutEnv.scala
@@ -1,6 +1,6 @@
-package com.phaller.spores.pickle.test
+package spores.pickle.test
 
-import com.phaller.spores.Builder
+import spores.Builder
 
 
 object SporeWithoutEnv extends Builder[Int, Int](

--- a/sample/src/main/scala/com/phaller/spores/sample/Agent.scala
+++ b/sample/src/main/scala/com/phaller/spores/sample/Agent.scala
@@ -1,4 +1,4 @@
-package com.phaller.spores.sample
+package spores.sample
 
 import upickle.default.*
 
@@ -10,8 +10,8 @@ import scala.concurrent.ExecutionContext
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 
-import com.phaller.spores.{Spore, Builder, SporeData, PackedSporeData}
-import com.phaller.spores.upickle.given
+import spores.{Spore, Builder, SporeData, PackedSporeData}
+import spores.upickle.given
 
 
 object AppendThree extends Builder[List[String], List[String]](

--- a/sample/src/main/scala/com/phaller/spores/sample/futures/FutureMap.scala
+++ b/sample/src/main/scala/com/phaller/spores/sample/futures/FutureMap.scala
@@ -1,4 +1,4 @@
-package com.phaller.spores.sample
+package spores.sample
 
 import scala.concurrent.{Future, Await}
 import scala.concurrent.duration.Duration
@@ -6,8 +6,8 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 import scala.collection.concurrent.TrieMap
 
-import com.phaller.spores.{Spore, Duplicable}
-import com.phaller.spores.Duplicable.duplicate
+import spores.{Spore, Duplicable}
+import spores.Duplicable.duplicate
 
 
 case class Customer(name: String, customerNo: Int)

--- a/sample/src/main/scala/com/phaller/spores/sample/futures/Futures.scala
+++ b/sample/src/main/scala/com/phaller/spores/sample/futures/Futures.scala
@@ -1,10 +1,10 @@
-package com.phaller.spores.sample
+package spores.sample
 
 import scala.concurrent.{Future, Await}
 import scala.concurrent.duration.Duration
 import scala.concurrent.ExecutionContext.Implicits.global
 
-import com.phaller.spores.Spore
+import spores.Spore
 
 
 object Futures:

--- a/sample/src/main/scala/com/phaller/spores/sample/futures/ParallelTreeReduction.scala
+++ b/sample/src/main/scala/com/phaller/spores/sample/futures/ParallelTreeReduction.scala
@@ -1,4 +1,4 @@
-package com.phaller.spores.sample
+package spores.sample
 
 import scala.util.Random
 
@@ -6,9 +6,9 @@ import scala.concurrent.{Future, Await}
 import scala.concurrent.duration.Duration
 import scala.concurrent.ExecutionContext.Implicits.global
 
-import com.phaller.spores.{Spore, Duplicable}
-import com.phaller.spores.Spore.thunk
-import com.phaller.spores.Duplicable.duplicate
+import spores.{Spore, Duplicable}
+import spores.Spore.thunk
+import spores.Duplicable.duplicate
 
 
 /**

--- a/shared/src/main/scala/com/phaller/spores/DSpore.scala
+++ b/shared/src/main/scala/com/phaller/spores/DSpore.scala
@@ -1,4 +1,4 @@
-package com.phaller.spores
+package spores
 
 
 object DSpore {

--- a/shared/src/main/scala/com/phaller/spores/Duplicable.scala
+++ b/shared/src/main/scala/com/phaller/spores/Duplicable.scala
@@ -1,4 +1,4 @@
-package com.phaller.spores
+package spores
 
 
 trait Duplicable[T]:

--- a/shared/src/main/scala/com/phaller/spores/Spore.scala
+++ b/shared/src/main/scala/com/phaller/spores/Spore.scala
@@ -1,4 +1,4 @@
-package com.phaller.spores
+package spores
 
 import _root_.upickle.default.*
 

--- a/shared/src/main/scala/com/phaller/spores/SporeData.scala
+++ b/shared/src/main/scala/com/phaller/spores/SporeData.scala
@@ -1,4 +1,4 @@
-package com.phaller.spores
+package spores
 
 import scala.quoted.*
 

--- a/shared/src/main/scala/com/phaller/spores/upickle/sporeDataReadWriter.scala
+++ b/shared/src/main/scala/com/phaller/spores/upickle/sporeDataReadWriter.scala
@@ -1,6 +1,6 @@
-package com.phaller.spores.upickle
+package spores.upickle
 
-import com.phaller.spores.{SporeData, PackedSporeData}
+import spores.{SporeData, PackedSporeData}
 
 import upickle.default.*
 

--- a/shared/src/test/scala/com/phaller/spores/test/DSporeTests.scala
+++ b/shared/src/test/scala/com/phaller/spores/test/DSporeTests.scala
@@ -1,10 +1,10 @@
-package com.phaller.spores.test
+package spores.test
 
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import com.phaller.spores.{Spore, DSpore}
+import spores.{Spore, DSpore}
 import Spore.thunk
 
 

--- a/shared/src/test/scala/com/phaller/spores/test/DuplicableTests.scala
+++ b/shared/src/test/scala/com/phaller/spores/test/DuplicableTests.scala
@@ -1,4 +1,3 @@
-package com.phaller
 package spores
 package test
 

--- a/shared/src/test/scala/com/phaller/spores/test/SporeTests.scala
+++ b/shared/src/test/scala/com/phaller/spores/test/SporeTests.scala
@@ -1,4 +1,3 @@
-package com.phaller
 package spores.test
 
 import org.junit.Test

--- a/shared/src/test/scala/com/phaller/spores/upickle/test/PickleTests.scala
+++ b/shared/src/test/scala/com/phaller/spores/upickle/test/PickleTests.scala
@@ -1,11 +1,11 @@
-package com.phaller.spores.pickle.test
+package spores.pickle.test
 
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import com.phaller.spores.{Spore, Creator, SporeData, PackedSporeData}
-import com.phaller.spores.upickle.given
+import spores.{Spore, Creator, SporeData, PackedSporeData}
+import spores.upickle.given
 
 import upickle.default.*
 
@@ -15,7 +15,7 @@ class PickleTests {
 
   @Test
   def testCreator(): Unit = {
-    val c = Creator[Int, Int, Int]("com.phaller.spores.pickle.test.MySpore")
+    val c = Creator[Int, Int, Int]("spores.pickle.test.MySpore")
     val s = c(12)
     val res = s(3)
     assert(res == 16)
@@ -55,7 +55,7 @@ class PickleTests {
     val data = SporeData(MySpore, Some(x))
     // pickle spore data
     val pickledData = write(data)
-    assert(pickledData == """["com.phaller.spores.pickle.test.MySpore",1,"12"]""")
+    assert(pickledData == """["spores.pickle.test.MySpore",1,"12"]""")
     val unpickledData = read[SporeData[Int, Int] { type Env = Int }](pickledData)
     assert(unpickledData.fqn == data.fqn)
     assert(unpickledData.envOpt == data.envOpt)
@@ -82,7 +82,7 @@ class PickleTests {
     val data = SporeData(MySpore, Some(x))
     // pickle spore data
     val pickledData = write(data)
-    assert(pickledData == """["com.phaller.spores.pickle.test.MySpore",1,"12"]""")
+    assert(pickledData == """["spores.pickle.test.MySpore",1,"12"]""")
     val unpickledData = read[SporeData[Int, Int] { type Env = Int }](pickledData)
     val unpickledSpore = unpickledData.toSpore
     assert(unpickledSpore(3) == 16)
@@ -93,7 +93,7 @@ class PickleTests {
     val data = SporeData(SporeWithoutEnv)
     // pickle spore data
     val pickledData = write(data)
-    assert(pickledData == """["com.phaller.spores.pickle.test.SporeWithoutEnv",0]""")
+    assert(pickledData == """["spores.pickle.test.SporeWithoutEnv",0]""")
     val unpickledData = read[SporeData[Int, Int] { type Env = Nothing }](pickledData)
     val unpickledSpore = unpickledData.toSpore
     assert(unpickledSpore(3) == 4)
@@ -105,7 +105,7 @@ class PickleTests {
     val data = SporeData(MySpore, Some(x))
     // pickle spore data
     val pickledData = write(data)
-    assert(pickledData == """["com.phaller.spores.pickle.test.MySpore",1,"12"]""")
+    assert(pickledData == """["spores.pickle.test.MySpore",1,"12"]""")
     val unpickledData = read[PackedSporeData](pickledData)
     val unpickledSpore = unpickledData.toSpore[Int, Int]
     assert(unpickledSpore(3) == 16)
@@ -116,7 +116,7 @@ class PickleTests {
     val data = SporeData(SporeWithoutEnv)
     // pickle spore data
     val pickledData = write(data)
-    assert(pickledData == """["com.phaller.spores.pickle.test.SporeWithoutEnv",0]""")
+    assert(pickledData == """["spores.pickle.test.SporeWithoutEnv",0]""")
     val unpickledData = read[PackedSporeData](pickledData)
     val unpickledSpore = unpickledData.toSpore[Int, Int]
     assert(unpickledSpore(3) == 4)
@@ -126,7 +126,7 @@ class PickleTests {
   def testPickleAppendString(): Unit = {
     val appendData = SporeData(AppendString, Some("three"))
     val serialized = write(appendData)
-    assert(serialized == """["com.phaller.spores.pickle.test.AppendString",1,"\"three\""]""")
+    assert(serialized == """["spores.pickle.test.AppendString",1,"\"three\""]""")
     val deserData = read[PackedSporeData](serialized)
     val deserSpore = deserData.toSpore[List[String], List[String]]
     val l3 = List("four")


### PR DESCRIPTION
Removes prefix "com.phaller", adopting convention followed by projects such as uPickle.