### PR TITLE
Add Spore extensions for `tupled` and `untupled`

### DIFF
--- a/core/jvm/src/test/scala/spores/jvm/AutoCaptureErrorTests.scala
+++ b/core/jvm/src/test/scala/spores/jvm/AutoCaptureErrorTests.scala
@@ -7,8 +7,8 @@ import org.junit.Assert.*
 
 import upickle.default.*
 
-import spores.*
-import spores.given
+import spores.default.*
+import spores.default.given
 import spores.TestUtils.*
 
 

--- a/core/jvm/src/test/scala/spores/jvm/AutoCaptureTests.scala
+++ b/core/jvm/src/test/scala/spores/jvm/AutoCaptureTests.scala
@@ -7,8 +7,8 @@ import org.junit.Assert.*
 
 import upickle.default.*
 
-import spores.*
-import spores.given
+import spores.default.*
+import spores.default.given
 import spores.TestUtils.*
 
 

--- a/core/jvm/src/test/scala/spores/jvm/SporeLambdaErrorTests.scala
+++ b/core/jvm/src/test/scala/spores/jvm/SporeLambdaErrorTests.scala
@@ -5,8 +5,8 @@ import org.junit.runners.JUnit4
 import org.junit.Test
 import org.junit.Assert.*
 
-import spores.given
-import spores.*
+import spores.default.given
+import spores.default.*
 import spores.TestUtils.*
 
 // // The following code should produce a compile error:

--- a/core/jvm/src/test/scala/spores/jvm/SporeLambdaTests.scala
+++ b/core/jvm/src/test/scala/spores/jvm/SporeLambdaTests.scala
@@ -5,8 +5,8 @@ import org.junit.runners.JUnit4
 import org.junit.Test
 import org.junit.Assert.*
 
-import spores.given
-import spores.*
+import spores.default.given
+import spores.default.*
 import spores.TestUtils.*
 
 object SporeLambdaTests:

--- a/core/jvm/src/test/scala/spores/test/SporeTests.scala
+++ b/core/jvm/src/test/scala/spores/test/SporeTests.scala
@@ -5,7 +5,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 import spores.Spore
-import spores.given
+import spores.default.given
 
 
 @RunWith(classOf[JUnit4])

--- a/core/jvm/src/test/scala/spores/test/TrieMapTest.scala
+++ b/core/jvm/src/test/scala/spores/test/TrieMapTest.scala
@@ -6,7 +6,8 @@ import org.junit.runners.JUnit4
 
 import scala.collection.concurrent.TrieMap
 
-import spores.{Duplicable, Duplicate}
+import spores.default.*
+import spores.default.given
 
 
 case class Customer(name: String, customerNo: Int)
@@ -33,7 +34,7 @@ class TrieMapTest {
       val sumAges = infos.foldLeft(0)(_ + _.age).toFloat
       if (infos.size == 0) 0
       else sumAges / infos.size
-    }.unwrap()
+    }
 
     val res = s(List())
     assert(res == 0)

--- a/core/shared/src/main/scala/spores/Conversions.scala
+++ b/core/shared/src/main/scala/spores/Conversions.scala
@@ -1,0 +1,22 @@
+package spores
+
+/** A collection of conversions. Contains conversions from `Spore[Function1[T1,
+  * R]]` to `Function1[T1, R]` etc..
+  */
+object Conversions {
+
+  given conversionSporeToFunction0[R]: Conversion[Spore[() => R], (() => R)] = { spore => spore.unwrap() }
+  given conversionSporeToFunction1[T1, R]: Conversion[Spore[T1 => R], (T1 => R)] = { spore => spore.unwrap() }
+  given conversionSporeToFunction2[T1, T2, R]: Conversion[Spore[(T1, T2) => R], ((T1, T2) => R)] = { spore => spore.unwrap() }
+  given conversionSporeToFunction3[T1, T2, T3, R]: Conversion[Spore[(T1, T2, T3) => R], ((T1, T2, T3) => R)] = { spore => spore.unwrap() }
+  given conversionSporeToFunction4[T1, T2, T3, T4, R]: Conversion[Spore[(T1, T2, T3, T4) => R], ((T1, T2, T3, T4) => R)] = { spore => spore.unwrap() }
+  given conversionSporeToFunction5[T1, T2, T3, T4, T5, R]: Conversion[Spore[(T1, T2, T3, T4, T5) => R], ((T1, T2, T3, T4, T5) => R)] = { spore => spore.unwrap() }
+  given conversionSporeToFunction6[T1, T2, T3, T4, T5, T6, R]: Conversion[Spore[(T1, T2, T3, T4, T5, T6) => R], ((T1, T2, T3, T4, T5, T6) => R)] = { spore => spore.unwrap() }
+  given conversionSporeToFunction7[T1, T2, T3, T4, T5, T6, T7, R]: Conversion[Spore[(T1, T2, T3, T4, T5, T6, T7) => R], ((T1, T2, T3, T4, T5, T6, T7) => R)] = { spore => spore.unwrap() }
+
+  // Conversions for context functions are not supported:
+  // > Implementation restriction: cannot convert this expression to
+  // > `Conversion[spores.Spore[(T1) ?=> R], (T1) ?=> R]` because its result
+  // > type `(T1) ?=> R` is a contextual function type.
+
+}

--- a/core/shared/src/main/scala/spores/Conversions.scala
+++ b/core/shared/src/main/scala/spores/Conversions.scala
@@ -19,4 +19,13 @@ object Conversions {
   // > `Conversion[spores.Spore[(T1) ?=> R], (T1) ?=> R]` because its result
   // > type `(T1) ?=> R` is a contextual function type.
 
+  given conversionDuplicateToFunction0[R]: Conversion[Duplicate[() => R], (() => R)] = { dup => dup.unwrap() }
+  given conversionDuplicateToFunction1[T1, R]: Conversion[Duplicate[T1 => R], (T1 => R)] = { dup => dup.unwrap() }
+  given conversionDuplicateToFunction2[T1, T2, R]: Conversion[Duplicate[(T1, T2) => R], ((T1, T2) => R)] = { dup => dup.unwrap() }
+  given conversionDuplicateToFunction3[T1, T2, T3, R]: Conversion[Duplicate[(T1, T2, T3) => R], ((T1, T2, T3) => R)] = { dup => dup.unwrap() }
+  given conversionDuplicateToFunction4[T1, T2, T3, T4, R]: Conversion[Duplicate[(T1, T2, T3, T4) => R], ((T1, T2, T3, T4) => R)] = { dup => dup.unwrap() }
+  given conversionDuplicateToFunction5[T1, T2, T3, T4, T5, R]: Conversion[Duplicate[(T1, T2, T3, T4, T5) => R], ((T1, T2, T3, T4, T5) => R)] = { dup => dup.unwrap() }
+  given conversionDuplicateToFunction6[T1, T2, T3, T4, T5, T6, R]: Conversion[Duplicate[(T1, T2, T3, T4, T5, T6) => R], ((T1, T2, T3, T4, T5, T6) => R)] = { dup => dup.unwrap() }
+  given conversionDuplicateToFunction7[T1, T2, T3, T4, T5, T6, T7, R]: Conversion[Duplicate[(T1, T2, T3, T4, T5, T6, T7) => R], ((T1, T2, T3, T4, T5, T6, T7) => R)] = { dup => dup.unwrap() }
+
 }

--- a/core/shared/src/main/scala/spores/Spore.scala
+++ b/core/shared/src/main/scala/spores/Spore.scala
@@ -139,37 +139,6 @@ sealed trait Spore[+T] {
       case PackedWithCtx(packed, packedEnv) => packed.unwrap()(using packedEnv.unwrap())
   }
 
-  def apply[R]()(using ev: T <:< (() => R)): R = {
-    this.unwrap().apply()
-  }
-
-  def apply[T1, R](arg1: T1)(using ev: T <:< (T1 => R)): R = {
-    this.unwrap().apply(arg1)
-  }
-
-  def apply[T1, T2, R](arg1: T1, arg2: T2)(using ev: T <:< ((T1, T2) => R)): R = {
-    this.unwrap().apply(arg1, arg2)
-  }
-
-  def apply[T1, T2, T3, R](arg1: T1, arg2: T2, arg3: T3)(using ev: T <:< ((T1, T2, T3) => R)): R = {
-    this.unwrap().apply(arg1, arg2, arg3)
-  }
-
-  def apply[T1, T2, T3, T4, R](arg1: T1, arg2: T2, arg3: T3, arg4: T4)(using ev: T <:< ((T1, T2, T3, T4) => R)): R = {
-    this.unwrap().apply(arg1, arg2, arg3, arg4)
-  }
-
-  def apply[T1, T2, T3, T4, T5, R](arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5)(using ev: T <:< ((T1, T2, T3, T4, T5) => R)): R = {
-    this.unwrap().apply(arg1, arg2, arg3, arg4, arg5)
-  }
-
-  def apply[T1, T2, T3, T4, T5, T6, R](arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6)(using ev: T <:< ((T1, T2, T3, T4, T5, T6) => R)): R = {
-    this.unwrap().apply(arg1, arg2, arg3, arg4, arg5, arg6)
-  }
-
-  def apply[T1, T2, T3, T4, T5, T6, T7, R](arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7)(using ev: T <:< ((T1, T2, T3, T4, T5, T6, T7) => R)): R = {
-    this.unwrap().apply(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
-  }
 }
 
 

--- a/core/shared/src/main/scala/spores/Tupled.scala
+++ b/core/shared/src/main/scala/spores/Tupled.scala
@@ -1,0 +1,41 @@
+package spores
+
+/** Extensions for `tupledN` and `untupledN` on Spores. */
+object Tupled {
+
+  private[spores] final class Tupled0[R] extends SporeClassBuilder[Function0[R] => Function1[EmptyTuple, R]]({ fun0 => { case EmptyTuple => fun0() } })
+  private[spores] final class Tupled1[T1, R] extends SporeClassBuilder[Function1[T1, R] => Function1[Tuple1[T1], R]]({ fun1 => { case Tuple1(x1) => fun1(x1) } })
+  private[spores] final class Tupled2[T1, T2, R] extends SporeClassBuilder[Function2[T1, T2, R] => Function1[Tuple2[T1, T2], R]]({ fun2 => fun2.tupled })
+  private[spores] final class Tupled3[T1, T2, T3, R] extends SporeClassBuilder[Function3[T1, T2, T3, R] => Function1[Tuple3[T1, T2, T3], R]]({ fun3 => fun3.tupled })
+  private[spores] final class Tupled4[T1, T2, T3, T4, R] extends SporeClassBuilder[Function4[T1, T2, T3, T4, R] => Function1[(T1, T2, T3, T4), R]]({ fun4 => fun4.tupled })
+  private[spores] final class Tupled5[T1, T2, T3, T4, T5, R] extends SporeClassBuilder[Function5[T1, T2, T3, T4, T5, R] => Function1[(T1, T2, T3, T4, T5), R]]({ fun5 => fun5.tupled })
+  private[spores] final class Tupled6[T1, T2, T3, T4, T5, T6, R] extends SporeClassBuilder[Function6[T1, T2, T3, T4, T5, T6, R] => Function1[(T1, T2, T3, T4, T5, T6), R]]({ fun6 => fun6.tupled })
+  private[spores] final class Tupled7[T1, T2, T3, T4, T5, T6, T7, R] extends SporeClassBuilder[Function7[T1, T2, T3, T4, T5, T6, T7, R] => Function1[(T1, T2, T3, T4, T5, T6, T7), R]]({ fun7 => fun7.tupled })
+
+  extension [R](spore: Spore[Function0[R]]) { def tupled0: Spore[Function1[EmptyTuple, R]] = new Tupled0[R]().build().withEnv2(spore) }
+  extension [T1, R](spore: Spore[Function1[T1, R]]) { def tupled1: Spore[Function1[Tuple1[T1], R]] = new Tupled1[T1, R]().build().withEnv2(spore) }
+  extension [T1, T2, R](spore: Spore[Function2[T1, T2, R]]) { def tupled2: Spore[Function1[Tuple2[T1, T2], R]] = new Tupled2[T1, T2, R]().build().withEnv2(spore) }
+  extension [T1, T2, T3, R](spore: Spore[Function3[T1, T2, T3, R]]) { def tupled3: Spore[Function1[Tuple3[T1, T2, T3], R]] = new Tupled3[T1, T2, T3, R]().build().withEnv2(spore) }
+  extension [T1, T2, T3, T4, R](spore: Spore[Function4[T1, T2, T3, T4, R]]) { def tupled4: Spore[Function1[(T1, T2, T3, T4), R]] = new Tupled4[T1, T2, T3, T4, R]().build().withEnv2(spore) }
+  extension [T1, T2, T3, T4, T5, R](spore: Spore[Function5[T1, T2, T3, T4, T5, R]]) { def tupled5: Spore[Function1[(T1, T2, T3, T4, T5), R]] = new Tupled5[T1, T2, T3, T4, T5, R]().build().withEnv2(spore) }
+  extension [T1, T2, T3, T4, T5, T6, R](spore: Spore[Function6[T1, T2, T3, T4, T5, T6, R]]) { def tupled6: Spore[Function1[(T1, T2, T3, T4, T5, T6), R]] = new Tupled6[T1, T2, T3, T4, T5, T6, R]().build().withEnv2(spore) }
+  extension [T1, T2, T3, T4, T5, T6, T7, R](spore: Spore[Function7[T1, T2, T3, T4, T5, T6, T7, R]]) { def tupled7: Spore[Function1[(T1, T2, T3, T4, T5, T6, T7), R]] = new Tupled7[T1, T2, T3, T4, T5, T6, T7, R]().build().withEnv2(spore) }
+
+  private[spores] final class Untupled0[R] extends SporeClassBuilder[Function1[EmptyTuple, R] => Function0[R]]({ fun0 => () => fun0(EmptyTuple) })
+  private[spores] final class Untupled1[T1, R] extends SporeClassBuilder[Function1[Tuple1[T1], R] => Function1[T1, R]]({ fun1 => t1 => fun1(Tuple1(t1)) })
+  private[spores] final class Untupled2[T1, T2, R] extends SporeClassBuilder[Function1[(T1, T2), R] => Function2[T1, T2, R]]({ fun2 => (t1, t2) => fun2((t1, t2)) })
+  private[spores] final class Untupled3[T1, T2, T3, R] extends SporeClassBuilder[Function1[(T1, T2, T3), R] => Function3[T1, T2, T3, R]]({ fun3 => (t1, t2, t3) => fun3((t1, t2, t3)) })
+  private[spores] final class Untupled4[T1, T2, T3, T4, R] extends SporeClassBuilder[Function1[(T1, T2, T3, T4), R] => Function4[T1, T2, T3, T4, R]]({ fun4 => (t1, t2, t3, t4) => fun4((t1, t2, t3, t4)) })
+  private[spores] final class Untupled5[T1, T2, T3, T4, T5, R] extends SporeClassBuilder[Function1[(T1, T2, T3, T4, T5), R] => Function5[T1, T2, T3, T4, T5, R]]({ fun5 => (t1, t2, t3, t4, t5) => fun5((t1, t2, t3, t4, t5)) })
+  private[spores] final class Untupled6[T1, T2, T3, T4, T5, T6, R] extends SporeClassBuilder[Function1[(T1, T2, T3, T4, T5, T6), R] => Function6[T1, T2, T3, T4, T5, T6, R]]({ fun6 => (t1, t2, t3, t4, t5, t6) => fun6((t1, t2, t3, t4, t5, t6)) })
+  private[spores] final class Untupled7[T1, T2, T3, T4, T5, T6, T7, R] extends SporeClassBuilder[Function1[(T1, T2, T3, T4, T5, T6, T7), R] => Function7[T1, T2, T3, T4, T5, T6, T7, R]]({ fun7 => (t1, t2, t3, t4, t5, t6, t7) => fun7((t1, t2, t3, t4, t5, t6, t7)) })
+
+  extension [R](spore: Spore[Function1[EmptyTuple, R]]) { def untupled0: Spore[Function0[R]] = new Untupled0[R]().build().withEnv2(spore) }
+  extension [T1, R](spore: Spore[Function1[Tuple1[T1], R]]) { def untupled1: Spore[Function1[T1, R]] = new Untupled1[T1, R]().build().withEnv2(spore) }
+  extension [T1, T2, R](spore: Spore[Function1[(T1, T2), R]]) { def untupled2: Spore[Function2[T1, T2, R]] = new Untupled2[T1, T2, R]().build().withEnv2(spore) }
+  extension [T1, T2, T3, R](spore: Spore[Function1[(T1, T2, T3), R]]) { def untupled3: Spore[Function3[T1, T2, T3, R]] = new Untupled3[T1, T2, T3, R]().build().withEnv2(spore) }
+  extension [T1, T2, T3, T4, R](spore: Spore[Function1[(T1, T2, T3, T4), R]]) { def untupled4: Spore[Function4[T1, T2, T3, T4, R]] = new Untupled4[T1, T2, T3, T4, R]().build().withEnv2(spore) }
+  extension [T1, T2, T3, T4, T5, R](spore: Spore[Function1[(T1, T2, T3, T4, T5), R]]) { def untupled5: Spore[Function5[T1, T2, T3, T4, T5, R]] = new Untupled5[T1, T2, T3, T4, T5, R]().build().withEnv2(spore) }
+  extension [T1, T2, T3, T4, T5, T6, R](spore: Spore[Function1[(T1, T2, T3, T4, T5, T6), R]]) { def untupled6: Spore[Function6[T1, T2, T3, T4, T5, T6, R]] = new Untupled6[T1, T2, T3, T4, T5, T6, R]().build().withEnv2(spore) }
+  extension [T1, T2, T3, T4, T5, T6, T7, R](spore: Spore[Function1[(T1, T2, T3, T4, T5, T6, T7), R]]) { def untupled7: Spore[Function7[T1, T2, T3, T4, T5, T6, T7, R]] = new Untupled7[T1, T2, T3, T4, T5, T6, T7, R]().build().withEnv2(spore) }
+}

--- a/core/shared/src/main/scala/spores/default.scala
+++ b/core/shared/src/main/scala/spores/default.scala
@@ -12,5 +12,6 @@ package object default {
   export spores.Duplicate
   export spores.ReadWriters.given
   export spores.Conversions.given
+  export spores.Tupled.*
 
 }

--- a/core/shared/src/main/scala/spores/default.scala
+++ b/core/shared/src/main/scala/spores/default.scala
@@ -1,0 +1,15 @@
+package spores
+
+package object default {
+
+  export spores.Spore
+  export spores.SporeBuilder
+  export spores.SporeClassBuilder
+  export spores.Env
+  export spores.Duplicable
+  export spores.Duplicable.given
+  export spores.Duplicate
+  export spores.ReadWriters.given
+  export spores.Conversions.given
+
+}

--- a/core/shared/src/main/scala/spores/default.scala
+++ b/core/shared/src/main/scala/spores/default.scala
@@ -8,6 +8,7 @@ package object default {
   export spores.Env
   export spores.Duplicable
   export spores.Duplicable.given
+  export spores.Duplicable.duplicate
   export spores.Duplicate
   export spores.ReadWriters.given
   export spores.Conversions.given

--- a/core/shared/src/main/scala/spores/package.scala
+++ b/core/shared/src/main/scala/spores/package.scala
@@ -5,8 +5,4 @@
   * Create a Spore using the factories in [[spores.Spore]], or by using the
   * [[spores.SporeBuilder]] or [[spores.SporeClassBuilder]].
   */
-package object spores {
-
-  export spores.ReadWriters.given
-
-}
+package object spores

--- a/core/shared/src/test/scala/spores/SporeClassBuilderErrorTests.scala
+++ b/core/shared/src/test/scala/spores/SporeClassBuilderErrorTests.scala
@@ -5,8 +5,8 @@ import org.junit.runners.JUnit4
 import org.junit.Test
 import org.junit.Assert.*
 
-import spores.given
-import spores.*
+import spores.default.given
+import spores.default.*
 import spores.TestUtils.*
 
 object SporeClassBuilderErrorTests:

--- a/core/shared/src/test/scala/spores/SporeClassBuilderTests.scala
+++ b/core/shared/src/test/scala/spores/SporeClassBuilderTests.scala
@@ -5,8 +5,8 @@ import org.junit.runners.JUnit4
 import org.junit.Test
 import org.junit.Assert.*
 
-import spores.given
-import spores.*
+import spores.default.given
+import spores.default.*
 import spores.TestUtils.*
 
 object SporeClassBuilderTests:

--- a/core/shared/src/test/scala/spores/SporeObjectBuilderErrorTests.scala
+++ b/core/shared/src/test/scala/spores/SporeObjectBuilderErrorTests.scala
@@ -5,8 +5,8 @@ import org.junit.runners.JUnit4
 import org.junit.Test
 import org.junit.Assert.*
 
-import spores.given
-import spores.*
+import spores.default.given
+import spores.default.*
 import spores.TestUtils.*
 
 object SporeBuilderErrorTests:

--- a/core/shared/src/test/scala/spores/SporeObjectBuilderTests.scala
+++ b/core/shared/src/test/scala/spores/SporeObjectBuilderTests.scala
@@ -5,8 +5,8 @@ import org.junit.runners.JUnit4
 import org.junit.Test
 import org.junit.Assert.*
 
-import spores.given
-import spores.*
+import spores.default.given
+import spores.default.*
 import spores.TestUtils.*
 
 object SporeBuilderTests:

--- a/core/shared/src/test/scala/spores/TupledTests.scala
+++ b/core/shared/src/test/scala/spores/TupledTests.scala
@@ -1,0 +1,82 @@
+package spores
+
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.junit.Test
+import org.junit.Assert.*
+
+import spores.default.*
+import spores.default.given
+
+object TupledTests {
+
+  object SporeFunUntupled0 extends SporeBuilder[Function0[Int]]({ () => 1 })
+  object SporeFunUntupled1 extends SporeBuilder[Function1[Int, Int]]({ (t1) => t1 + 1 })
+  object SporeFunUntupled2 extends SporeBuilder[Function2[String, String, String]]({ (t1, t2) => t1 + t2 })
+
+  class Foo(x: Int) {
+    override def toString(): String = s"Foo($x)"
+  }
+  object SporeFunUntupled3 extends SporeBuilder[Function3[Foo, Int, String, String]]({ (t1, t2, t3) => t1.toString() + t2.toString() + t3 })
+
+  object SporeFunUntupled4 extends SporeBuilder[Function4[Int, Int, Int, Int, Int]]({ (t1, t2, t3, t4) => t1 + t2 + t3 + t4 })
+  object SporeFunUntupled5 extends SporeBuilder[Function5[Int, Int, Int, Int, Int, Int]]({ (t1, t2, t3, t4, t5) => t1 + t2 + t3 + t4 + t5 })
+  object SporeFunUntupled6 extends SporeBuilder[Function6[Int, Int, Int, Int, Int, Int, Int]]({ (t1, t2, t3, t4, t5, t6) => t1 + t2 + t3 + t4 + t5 + t6 })
+  object SporeFunUntupled7 extends SporeBuilder[Function7[Int, Int, Int, Int, Int, Int, Int, Int]]({ (t1, t2, t3, t4, t5, t6, t7) => t1 + t2 + t3 + t4 + t5 + t6 + t7 })
+
+  object SporeFunTupled0 extends SporeBuilder[Function1[EmptyTuple, Int]]({ _ => 1 })
+  object SporeFunTupled1 extends SporeBuilder[Function1[Tuple1[Int], Int]]({ case Tuple1(x1) => x1 + 1 })
+  object SporeFunTupled2 extends SporeBuilder[Function1[(String, String), String]]({ case (x1, x2) => x1 + x2 })
+  object SporeFunTupled3 extends SporeBuilder[Function1[(Foo, Int, String), String]]({ case (x1, x2, x3) => x1.toString() + x2.toString() + x3 })
+  object SporeFunTupled4 extends SporeBuilder[Function1[(Int, Int, Int, Int), Int]]({ case (x1, x2, x3, x4) => x1 + x2 + x3 + x4 })
+  object SporeFunTupled5 extends SporeBuilder[Function1[(Int, Int, Int, Int, Int), Int]]({ case (x1, x2, x3, x4, x5) => x1 + x2 + x3 + x4 + x5 })
+  object SporeFunTupled6 extends SporeBuilder[Function1[(Int, Int, Int, Int, Int, Int), Int]]({ case (x1, x2, x3, x4, x5, x6) => x1 + x2 + x3 + x4 + x5 + x6 })
+  object SporeFunTupled7 extends SporeBuilder[Function1[(Int, Int, Int, Int, Int, Int, Int), Int]]({ case (x1, x2, x3, x4, x5, x6, x7) => x1 + x2 + x3 + x4 + x5 + x6 + x7 })
+}
+
+@RunWith(classOf[JUnit4])
+class TupledTests {
+  import TupledTests.*
+
+  @Test
+  def testTupled(): Unit = {
+    val f0 = SporeFunUntupled0.build().tupled0
+    val f1 = SporeFunUntupled1.build().tupled1
+    val f2 = SporeFunUntupled2.build().tupled2
+    val f3 = SporeFunUntupled3.build().tupled3
+    val f4 = SporeFunUntupled4.build().tupled4
+    val f5 = SporeFunUntupled5.build().tupled5
+    val f6 = SporeFunUntupled6.build().tupled6
+    val f7 = SporeFunUntupled7.build().tupled7
+
+    assertEquals(1, f0(EmptyTuple))
+    assertEquals(2, f1(Tuple1(1)))
+    assertEquals("HelloWorld", f2(("Hello", "World")))
+    assertEquals("Foo(1)12", f3(Tuple3(new Foo(1), 1, "2")))
+    assertEquals(10, f4((1, 2, 3, 4)))
+    assertEquals(15, f5((1, 2, 3, 4, 5)))
+    assertEquals(21, f6((1, 2, 3, 4, 5, 6)))
+    assertEquals(28, f7((1, 2, 3, 4, 5, 6, 7)))
+  }
+
+  @Test
+  def testUntupled(): Unit = {
+    val f0 = SporeFunTupled0.build().untupled0
+    val f1 = SporeFunTupled1.build().untupled1
+    val f2 = SporeFunTupled2.build().untupled2
+    val f3 = SporeFunTupled3.build().untupled3
+    val f4 = SporeFunTupled4.build().untupled4
+    val f5 = SporeFunTupled5.build().untupled5
+    val f6 = SporeFunTupled6.build().untupled6
+    val f7 = SporeFunTupled7.build().untupled7
+
+    assertEquals(1, f0())
+    assertEquals(2, f1(1))
+    assertEquals("HelloWorld", f2("Hello", "World"))
+    assertEquals("Foo(1)12", f3(new Foo(1), 1, "2"))
+    assertEquals(10, f4(1, 2, 3, 4))
+    assertEquals(15, f5(1, 2, 3, 4, 5))
+    assertEquals(21, f6(1, 2, 3, 4, 5, 6))
+    assertEquals(28, f7(1, 2, 3, 4, 5, 6, 7))
+  }
+}

--- a/core/shared/src/test/scala/spores/test/DuplicableTests.scala
+++ b/core/shared/src/test/scala/spores/test/DuplicableTests.scala
@@ -5,8 +5,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-import spores.Duplicable.duplicate
-import spores.Duplicate
+import spores.default.*
+import spores.default.given
 
 
 class C {
@@ -42,7 +42,7 @@ class DuplicableTests {
 
     val b2 = duplicate(b)
 
-    val res = b2.unwrap()()
+    val res = b2()
     assert(res == 6)
   }
 
@@ -57,7 +57,7 @@ class DuplicableTests {
 
     val b2 = duplicate(b)
 
-    val res = b2.unwrap()()
+    val res = b2()
     assert(res == 5)
 
     val dup = b.asInstanceOf[DuplicateWithEnv[C, Int]]
@@ -76,7 +76,7 @@ class DuplicableTests {
 
     val b2 = duplicate(b)
 
-    val envVal = b2.unwrap()()
+    val envVal = b2()
 
     assert(envVal != x)
   }
@@ -92,7 +92,7 @@ class DuplicableTests {
 
     val b2 = duplicate(b)
 
-    val envVal = b2.unwrap()()
+    val envVal = b2()
 
     assert(envVal.f == 7)
     assert(envVal ne x)
@@ -109,7 +109,7 @@ class DuplicableTests {
 
     val b2 = duplicate(b)
 
-    val envVal = b2.unwrap()()
+    val envVal = b2()
 
     assert(envVal.f == 7)
     assert(envVal ne x)
@@ -122,7 +122,7 @@ class DuplicableTests {
       (x: Int) => x + 2
     }
     val s2 = duplicate(s)
-    val res = s2.unwrap()(3)
+    val res = s2(3)
     assert(res == 5)
   }
 
@@ -136,7 +136,7 @@ class DuplicableTests {
     }
 
     val b2 = duplicate(b)
-    val res = b2.unwrap()(3)
+    val res = b2(3)
     assert(res == 7)
   }
 
@@ -145,7 +145,7 @@ class DuplicableTests {
     def duplicateThenApply[T, R, B <: Duplicate[T => R] : Duplicable](spore: B, arg: T): R = {
       val dup = summon[Duplicable[B]]
       val duplicated = dup.duplicate(spore)
-      duplicated.unwrap()(arg)
+      duplicated(arg)
     }
 
     val x = new C
@@ -162,7 +162,7 @@ class DuplicableTests {
   @Test
   def testPassingSpore(): Unit = {
     def m2(s: Duplicate[Int => Int], arg: Int): Int = {
-      s.unwrap()(arg)
+      s(arg)
     }
 
     def m1(s: Duplicate[Int => Int]): Int = {
@@ -185,7 +185,7 @@ class DuplicableTests {
     def m2[B <: Duplicate[Int => Int] : Duplicable](spore: B, arg: Int): Int = {
       val dup = summon[Duplicable[B]]
       val duplicated = dup.duplicate(spore)
-      duplicated.unwrap()(arg)
+      duplicated(arg)
     }
 
     def m1[B <: Duplicate[Int => Int] : Duplicable](spore: B): Int = {
@@ -208,7 +208,7 @@ class DuplicableTests {
     def duplicateThenApply[S <: Duplicate[Unit => C] : Duplicable](s: S): C = {
       val dup = summon[Duplicable[S]]
       val duplicated = dup.duplicate(s)
-      duplicated.unwrap().apply(())
+      duplicated(())
     }
 
     val x = new C

--- a/core/shared/src/test/scala/spores/upickle/test/PickleTests.scala
+++ b/core/shared/src/test/scala/spores/upickle/test/PickleTests.scala
@@ -7,7 +7,7 @@ import org.junit.runners.JUnit4
 import upickle.default.*
 
 import spores.{Spore, Reflection, SporeBuilder}
-import spores.given
+import spores.default.given
 
 
 @RunWith(classOf[JUnit4])

--- a/sample/jvm/src/main/scala/spores/sample/Agent.scala
+++ b/sample/jvm/src/main/scala/spores/sample/Agent.scala
@@ -11,7 +11,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 
 import spores.{Spore, SporeBuilder}
-import spores.given
+import spores.default.given
 
 
 object AppendThree extends SporeBuilder[List[String] => List[String]](

--- a/sample/jvm/src/main/scala/spores/sample/Agent.scala
+++ b/sample/jvm/src/main/scala/spores/sample/Agent.scala
@@ -10,7 +10,7 @@ import scala.concurrent.ExecutionContext
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 
-import spores.{Spore, SporeBuilder}
+import spores.default.*
 import spores.default.given
 
 
@@ -96,8 +96,7 @@ class Agent[T : ReadWriter] (init: T) { self =>
           mailbox.poll() match {
             case ApplyBlock(serialized) =>
               // deserialize
-              val unpickledData = read[Spore[T => T]](serialized)
-              val unpickledSpore = unpickledData.unwrap()
+              val unpickledSpore = read[Spore[T => T]](serialized)
 
               // update state by applying the unpickled spore
               val oldState = state.get()

--- a/sample/jvm/src/main/scala/spores/sample/AutoCaptureExample.scala
+++ b/sample/jvm/src/main/scala/spores/sample/AutoCaptureExample.scala
@@ -2,8 +2,8 @@ package spores.sample
 
 import upickle.default.*
 
-import spores.*
-import spores.given
+import spores.default.*
+import spores.default.given
 
 
 object AutoCaptureExample {

--- a/sample/jvm/src/main/scala/spores/sample/LambdaExample.scala
+++ b/sample/jvm/src/main/scala/spores/sample/LambdaExample.scala
@@ -1,7 +1,7 @@
 package spores.sample
 
-import spores.*
-import spores.given
+import spores.default.*
+import spores.default.given
 import spores.sample.platform.*
 
 

--- a/sample/jvm/src/main/scala/spores/sample/futures/FutureMap.scala
+++ b/sample/jvm/src/main/scala/spores/sample/futures/FutureMap.scala
@@ -6,8 +6,8 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 import scala.collection.concurrent.TrieMap
 
-import spores.{Duplicate, Duplicable}
-import spores.Duplicable.duplicate
+import spores.default.*
+import spores.default.given
 
 
 case class Customer(name: String, customerNo: Int)
@@ -44,7 +44,7 @@ object FutureMap {
       if (infos.nonEmpty) sumAges / infos.size else 0.0f
     }
     val safeSpore = duplicate(spore)
-    Future { safeSpore.unwrap().apply(customers) }
+    Future { safeSpore(customers) }
   }
 
   def main(args: Array[String]): Unit = {

--- a/sample/jvm/src/main/scala/spores/sample/futures/Futures.scala
+++ b/sample/jvm/src/main/scala/spores/sample/futures/Futures.scala
@@ -4,8 +4,8 @@ import scala.concurrent.{Future, Await}
 import scala.concurrent.duration.Duration
 import scala.concurrent.ExecutionContext.Implicits.global
 
-import spores.{Duplicable, Duplicate}
-import spores.Duplicate.given
+import spores.default.*
+import spores.default.given
 
 
 object Futures:
@@ -26,16 +26,12 @@ object Futures:
       val fut2 = fib(n - 2)
 
       // captured variables are passed explicitly to
-      // `apply` method of `Block` object
-      fut1.flatMap(
-        Duplicate.applyWithEnv(fut2) { fut2 => (res1: Int) =>
-          fut2.map(
-            Duplicate.applyWithEnv(res1) {
-              res1 => (res2: Int) => res1 + res2
-            }.unwrap()
-          )
-        }.unwrap()
-      )
+      // `applyWithEnv` method of `Spore` object
+      fut1.flatMap(Duplicate.applyWithEnv(fut2) { fut2 => (res1: Int) =>
+        fut2.map(Duplicate.applyWithEnv(res1) {
+          res1 => (res2: Int) => res1 + res2
+        })
+      })
 
   def main(args: Array[String]): Unit =
     // computes 8th Fibonacci number = 21

--- a/sample/jvm/src/main/scala/spores/sample/futures/ParallelTreeReduction.scala
+++ b/sample/jvm/src/main/scala/spores/sample/futures/ParallelTreeReduction.scala
@@ -6,8 +6,8 @@ import scala.concurrent.{Future, Await}
 import scala.concurrent.duration.Duration
 import scala.concurrent.ExecutionContext.Implicits.global
 
-import spores.{Duplicate, Duplicable}
-import spores.Duplicable.duplicate
+import spores.default.*
+import spores.default.given
 
 
 /**
@@ -69,9 +69,9 @@ object ParallelTreeReduction {
     * environment, is first duplicated. The created future only uses
     * and executes the duplicated block.
     */
-  def safeFuture[R](spore: Duplicate[R]) = {
+  def safeFuture[R](spore: Duplicate[() => R]): Future[R] = {
     val safeSpore = duplicate(spore)
-    Future { safeSpore.unwrap() }
+    Future { safeSpore() }
   }
 
   /** Implements parallel tree reduction using blocks and futures.
@@ -98,11 +98,11 @@ object ParallelTreeReduction {
 
     case Branch(left, data, right) =>
 
-      val leftBlock = Duplicate.applyWithEnv(left) { env =>
+      val leftBlock = Duplicate.applyWithEnv(left) { env => () =>
         parReduce(env)
       }
 
-      val rightBlock = Duplicate.applyWithEnv(right) { env =>
+      val rightBlock = Duplicate.applyWithEnv(right) { env => () =>
         parReduce(env)
       }
 

--- a/sample/shared/src/main/scala/sporks/sample/BuilderExample.scala
+++ b/sample/shared/src/main/scala/sporks/sample/BuilderExample.scala
@@ -1,7 +1,7 @@
 package spores.sample
 
-import spores.*
-import spores.given
+import spores.default.*
+import spores.default.given
 import spores.sample.platform.*
 
 


### PR DESCRIPTION
This PR adds methods for tupling and untupling a spore.

Example:
```scala
val spore: Spore[(Int, Int) => String] = Spore.apply { (x, y) => (x + y).toString() }
val tupledSpore = spore.tupled2
tupledSpore // has type Spore[((Int, Int) => String]
val untupledSpore = tupledSpore.untupled2
untupledSpore // has type Spore[(Int, Int) => String]
```

The PR builds on #24 as to export the new extensions in the default package.