### PR TITLE
Update versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
-lazy val Scala33 = "3.3.6"
-lazy val upickleVersion = "3.1.0"
+lazy val Scala33 = "3.3.4"
+lazy val upickleVersion = "3.3.0"
 lazy val junitInterfaceVersion = "0.11"
 
 ThisBuild / organization := "com.phaller"
@@ -56,7 +56,7 @@ lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
     name := "spores3",
     libraryDependencies += "com.lihaoyi" %%% "upickle" % upickleVersion,
     libraryDependencies += "com.novocode" % "junit-interface" % junitInterfaceVersion % "test",
-    testOptions += Tests.Argument(TestFrameworks.JUnit, "-q", "-v"),
+    testOptions += Tests.Argument(TestFrameworks.JUnit, "-v"),
   )
   .jsConfigure(_.enablePlugins(ScalaJSJUnitPlugin))
   .nativeConfigure(_.enablePlugins(ScalaNativeJUnitPlugin))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,9 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.19.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.13.0")
 
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.2.0")
 
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.17")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.6")
 
-addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.2.0")
 
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1")


### PR DESCRIPTION
This PR updates versions for Scala Native 0.5.X and wider compatibility.

The Scala version is set to 3.3.4.

A strange issue with Scala 3.3.1, 3.3.2, and 3.3.3 was discovered which would cause an exception `java.lang.NoSuchMethodException: Test$Foo$$anon$1.&lt;init&gt;()` for this example:

```scala
object Test {
  trait Foo {}

  object Foo {
    def fresh(): Foo = new Foo {}
  }
  
  def main(args: Array[String]): Unit = {
    val className = Foo.fresh().getClass().getName()
    println(className)
    val classInstance = Class.forName(className).getDeclaredConstructor().newInstance().asInstanceOf[Foo]
    println(classInstance)
  }
}
```

It is better if we stay away from those versions for now.

The Scala Native version is updated to 0.5.6, the lowest version which is compatible with Scala 3.3.4. The other versions are adapted accordingly.

The JUnit argument `-q` had to be removed for compatibility issues with Scala Native 0.5.X.

The updated versions are: Scala 3.3.6 -> 3.3.4; uPickle 3.1.0 -> 3.3.0; sbt-scalajs 1.19.0 -> 1.13.0; sbt-scala-native 0.4.17 -> 0.5.6.