### PR TITLE
Fix GitHub Actions for Windows

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,6 +16,8 @@ jobs:
             java: 17
           - os: ubuntu-latest
             java: 21
+          - os: ubuntu-latest
+            java: 25
           - os: macos-latest
             java: 17
           - os: windows-latest
@@ -46,12 +48,6 @@ jobs:
         curl.exe -L https://repo1.maven.org/maven2/com/lihaoyi/mill-dist/1.1.5/mill-dist-1.1.5-mill.bat -o mill.bat
         ./mill version
     - name: Build
-      run: |
-        ./mill __.jvm.compile
-        ./mill __.js.compile
-        ./mill __.native.compile
+      run: ./mill __.compile
     - name: Test
-      run: |
-        ./mill __.jvm.test
-        ./mill __.js.test
-        ./mill __.native.test
+      run: ./mill __.test


### PR DESCRIPTION
This PR fixes an issue with Windows not failing on GitHub Actions even though some of the test cases fail.

I noticed this issue sometime last week. To demonstrate it, I added a failing test case `testAlwaysFail` with `assert(false)`. All GitHub Actions runs fail except for Windows: https://github.com/jspenger/spores3/actions/runs/24459027889. This is fixed by this PR: https://github.com/jspenger/spores3/actions/runs/24460187815.

(Also adds JDK 25.)